### PR TITLE
Add =encoding to source files

### DIFF
--- a/Changelog.ini
+++ b/Changelog.ini
@@ -4,7 +4,7 @@ Changelog.Creator=Module::Metadata::Changes V 2.05
 Changelog.Parser=Config::IniFiles V 2.82
 
 [V 0.0022]
-Date=2011-03-12T00:00:00
+Date=2011-03-12T12:00:00
 Comments= <<EOT
 - no real change
 - Fix test again for 5.6 sake
@@ -12,25 +12,25 @@ Comments= <<EOT
 EOT
 
 [V 0.0021]
-Date=2011-03-12T00:00:00
+Date=2011-03-12T12:00:00
 Comments= <<EOT
 - no real change
 - New test fix for happy 5.6 testing
 EOT
 
 [V 0.0020]
-Date=2011-03-10T00:00:00
+Date=2011-03-10T12:00:00
 Comments= <<EOT
 - no real change
 - Test fixes for keeping 5.6 happy
 EOT
 
 [V 0.0019]
-Date=2011-03-09T00:00:00
+Date=2011-03-09T12:00:00
 Comments=- Dumper updated to work with Data::Dump 1.16+
 
 [V 0.0018]
-Date=2008-10-25T00:00:00
+Date=2008-10-25T12:00:00
 Comments= <<EOT
 - fix t/11version.t to deal with IPC::Cmd $err
 as an error message (undef on success) rather
@@ -40,7 +40,7 @@ http://rt.cpan.org/Ticket/Display.html?id=40157
 EOT
 
 [V 0.0017]
-Date=2008-03-09T00:00:00
+Date=2008-03-09T12:00:00
 Comments= <<EOT
 - assume this is not supposed to work for Perls
 under 5.6.0
@@ -52,7 +52,7 @@ for testing
 EOT
 
 [V 0.0016]
-Date=2008-03-03T00:00:00
+Date=2008-03-03T12:00:00
 Comments= <<EOT
 - quit is now a method
 - history is now persistent across sections
@@ -62,7 +62,7 @@ and File::Slurp
 EOT
 
 [V 0.0015]
-Date=2007-07-27T00:00:00
+Date=2007-07-27T12:00:00
 Comments= <<EOT
 - fixed 'quit'
 - the first of the Expect tests: t/20expect_quit.t
@@ -70,7 +70,7 @@ Comments= <<EOT
 EOT
 
 [V 0.0014]
-Date=2007-07-26T00:00:00
+Date=2007-07-26T12:00:00
 Comments= <<EOT
 - Shell::Perl now prints to the output stream of the
 associated term
@@ -80,7 +80,7 @@ associated term
 EOT
 
 [V 0.0013]
-Date=2007-06-21T00:00:00
+Date=2007-06-21T12:00:00
 Comments= <<EOT
 - the dumpers now deparse Perl code
 - added new dumper based on Data::Dump::Streamer,
@@ -88,7 +88,7 @@ no docs by now (try it with ":set out DDS")
 EOT
 
 [V 0.0012]
-Date=2007-06-21T00:00:00
+Date=2007-06-21T12:00:00
 Comments= <<EOT
 - added an experimental "dump history" command
 (RT #26973, by mgrimes)
@@ -96,7 +96,7 @@ Comments= <<EOT
 EOT
 
 [V 0.0011]
-Date=2007-06-21T00:00:00
+Date=2007-06-21T12:00:00
 Comments= <<EOT
 - some minor improvements to Makefile.PL - conformance
 to META.yml specification
@@ -107,7 +107,7 @@ between lines is not nice (to say the least)
 EOT
 
 [V 0.0010]
-Date=2007-03-14T00:00:00
+Date=2007-03-14T12:00:00
 Comments= <<EOT
 - this is a read-eval-print loop and not a
 read-eval-loop, doh
@@ -128,7 +128,7 @@ warnings and errors (Lorn again)
 EOT
 
 [V 0.0009]
-Date=2007-03-13T00:00:00
+Date=2007-03-13T12:00:00
 Comments= <<EOT
 - forgot README in MANIFEST
 - the default evaluation package is now
@@ -136,7 +136,7 @@ Comments= <<EOT
 EOT
 
 [V 0.0008]
-Date=2007-03-13T00:00:00
+Date=2007-03-13T12:00:00
 Comments= <<EOT
 - cmarcelo: some doc typos fixed
 - a SEE ALSO section
@@ -144,11 +144,11 @@ Comments= <<EOT
 EOT
 
 [V 0.0007]
-Date=2007-03-07T00:00:00
+Date=2007-03-07T12:00:00
 Comments=- added some POD to Shell.pm and pirl source files
 
 [V 0.0006]
-Date=2007-02-23T00:00:00
+Date=2007-02-23T12:00:00
 Comments= <<EOT
 - sources imported to Google code (no history :(, yet)
 - patches by cmarcelo:
@@ -159,19 +159,25 @@ does not pass yet
 EOT
 
 [V 0.0005]
-Date=2007-01-27T00:00:00
+Date=2007-01-27T12:00:00
 Comments=- relax the restrictions during eval - no strict qw(vars subs)
 
 [V 0.0004]
-Date=2007-01-25T00:00:00
+Date=2007-01-25T12:00:00
 Comments=- the same changes as before, now working
 
 [V 0.0003]
-Date=2007-01-25T00:00:00
+Date=2007-01-25T12:00:00
 Comments= <<EOT
 - prompt changes with the script name
 - psh renamed to pirl
 - borked
-0.0002 ?
-0.0001 ?
 EOT
+
+[V 0.0002]
+Date=2007-01-24T12:00:00
+Comments=- Date fabricated.
+
+[V 0.0001]
+Date=2007-01-23T12:00:00
+Comments=- Date fabricated.

--- a/Changes
+++ b/Changes
@@ -1,130 +1,130 @@
 Revision history for Perl extension Shell::Perl.
 
-1.23  Fri Jan 14:05:00 2014
+0.0023  Fri Jan 14:05:00 2014
 	- Update Makefile.PL from 'use 5.006' to 'use 5.008' as per RT#43117. Thanx ANDK.
 	- Fix dates in this file.
-	- Change version numbering in this file from 0.0023 to 1.23.
 
-0.0022  Mar 12, 2011
-        - no real change
-        - Fix test again for 5.6 sake
-        - Improved Makefile.PL / META.yml
+0.0022  Sat Mar 12 12:00:00 2011
+	- no real change
+	- Fix test again for 5.6 sake
+	- Improved Makefile.PL / META.yml
 
-0.0021  Mar 12, 2011
-        - no real change
-        - New test fix for happy 5.6 testing
+0.0021  Sat Mar 12 12:00:00 2011
+	- no real change
+	- New test fix for happy 5.6 testing
 
-0.0020  Mar 10, 2011
-        - no real change
-        - Test fixes for keeping 5.6 happy
+0.0020  Thu Mar 10 12:00:00 2011
+	- no real change
+	- Test fixes for keeping 5.6 happy
 
-0.0019  Mar 9, 2011
-        - Dumper updated to work with Data::Dump 1.16+
+0.0019  Wed Mar 09 12:00:00 2011
+	- Dumper updated to work with Data::Dump 1.16+
 
-0.0018  Oct 25, 2008
-        - fix t/11version.t to deal with IPC::Cmd $err
-          as an error message (undef on success) rather
-          than an error code (0 on success)
-          [Thanks, Andreas, for spotting that]
-          http://rt.cpan.org/Ticket/Display.html?id=40157
+0.0018  Sat Oct 25 12:00:00 2008
+	- fix t/11version.t to deal with IPC::Cmd $err
+		as an error message (undef on success) rather
+		than an error code (0 on success)
+		[Thanks, Andreas, for spotting that]
+		http://rt.cpan.org/Ticket/Display.html?id=40157
 
-0.0017  Mar  9, 2008
-        - assume this is not supposed to work for Perls
-          under 5.6.0
-        - cope with noisy 5.6 blib at t/20expect_quit.t
-          (illustrated by test report http://www.nntp.perl.org/group/perl.cpan.testers/2008/03/msg1099937.html)
-        - pirl now accepts switches --version and -v
-        - added IPC::Cmd and Test::Deep as prerequisites
-          for testing
+0.0017  Sun Mar 09 12:00:00 2008
+	- assume this is not supposed to work for Perls
+		under 5.6.0
+	- cope with noisy 5.6 blib at t/20expect_quit.t
+		(illustrated by test report http://www.nntp.perl.org/group/perl.cpan.testers/2008/03/msg1099937.html)
+	- pirl now accepts switches --version and -v
+	- added IPC::Cmd and Test::Deep as prerequisites
+		for testing
 
-0.0016  Mar  3, 2008
-        - quit is now a method
-        - history is now persistent across sections
-          (should work with T::RL::Gnu and T::RL::Perl)
-        - new dependencies: File::HomeDir, Path::Class,
-          and File::Slurp
+0.0016  Mon Mar 03 12:00:00 2008
+	- quit is now a method
+	- history is now persistent across sections
+		(should work with T::RL::Gnu and T::RL::Perl)
+	- new dependencies: File::HomeDir, Path::Class,
+		and File::Slurp
 
-0.0015  Jul 27, 2007
-        - fixed 'quit'
-        - the first of the Expect tests: t/20expect_quit.t
-        - pirl now accepts switches --ornaments and --noornaments
+0.0015  Fri Jul 27 12:00:00 2007
+	- fixed 'quit'
+	- the first of the Expect tests: t/20expect_quit.t
+	- pirl now accepts switches --ornaments and --noornaments
 
-0.0014  Jul 26, 2007
-        - Shell::Perl now prints to the output stream of the
-          associated term
-        - new test t/10compile.t
-        - :x is the same as :exit, :quit, :q
-        - quit is an alias to "sub { exit }" in the sandbox package
+0.0014  Thu Jul 26 12:00:00 2007
+	- Shell::Perl now prints to the output stream of the
+		associated term
+	- new test t/10compile.t
+	- :x is the same as :exit, :quit, :q
+	- quit is an alias to "sub { exit }" in the sandbox package
 
-0.0013  Jun 21, 2007
-        - the dumpers now deparse Perl code
-        - added new dumper based on Data::Dump::Streamer,
-          no docs by now (try it with ":set out DDS")
+0.0013  Thu Jun 21 12:00:00 2007
+	- the dumpers now deparse Perl code
+	- added new dumper based on Data::Dump::Streamer,
+		no docs by now (try it with ":set out DDS")
 
-0.0012  Jun 21, 2007
-        - added an experimental "dump history" command
-          (RT #26973, by mgrimes)
-        - hopefully get rid of the double newline in eval output
+0.0012  Thu Jun 21 12:00:00 2007
+	- added an experimental "dump history" command
+		(RT #26973, by mgrimes)
+	- hopefully get rid of the double newline in eval output
 
-0.0011  Jun 21, 2007 [worked around Mar 15, 2007]
-        - some minor improvements to Makefile.PL - conformance
-          to META.yml specification
-        - when dumping YAML, prefer YAML::Syck to YAML if available
-        - we have a bug to fix: the REPL and the running interpreter
-          share global state (like $_) and so relying on these
-          between lines is not nice (to say the least)
+0.0011  Thu Jun 21 12:00:00 2007
+	- some minor improvements to Makefile.PL - conformance
+		to META.yml specification
+	- when dumping YAML, prefer YAML::Syck to YAML if available
+	- we have a bug to fix: the REPL and the running interpreter
+		share global state (like $_) and so relying on these
+		between lines is not nice (to say the least)
 
-0.0010  Mar 14, 2007
-        - this is a read-eval-print loop and not a
-          read-eval-loop, doh
-        - total rewrite for the implementation of dumpers
-        - new output style with the plain dumper (idea
-          borrowed from Sepia by Sean O'Rourke)
-        - Data::Dump, Data::Dumper, YAML are only required
-          at runtime and fail gracefully if not there
-        - the preferred dumper is via Data::Dump, but it
-          falls back to Data::Dumper, YAML and the plain
-          dumper according to availability
-        - fix bug: inline contexts (like #scalar)
-          were not being respected for printing
-        - Makefile.PL required ExtUtils::MakeMaker 6.31
-          and we are more tolerant now (thanks, Lorn)
-        - now the right line number is used at
-          warnings and errors (Lorn again)
+0.0010  Wed Mar 14 12:00:00 2007
+	- this is a read-eval-print loop and not a
+		read-eval-loop, doh
+	- total rewrite for the implementation of dumpers
+	- new output style with the plain dumper (idea
+		borrowed from Sepia by Sean O'Rourke)
+	- Data::Dump, Data::Dumper, YAML are only required
+		at runtime and fail gracefully if not there
+	- the preferred dumper is via Data::Dump, but it
+		falls back to Data::Dumper, YAML and the plain
+		dumper according to availability
+	- fix bug: inline contexts (like #scalar)
+		were not being respected for printing
+	- Makefile.PL required ExtUtils::MakeMaker 6.31
+		and we are more tolerant now (thanks, Lorn)
+	- now the right line number is used at
+		warnings and errors (Lorn again)
 
-0.0009  Mar 13, 2007
-        - forgot README in MANIFEST
-        - the default evaluation package is now
-          "Shell::Perl::sandbox"
+0.0009  Tue Mar 13 12:00:00 2007
+	- forgot README in MANIFEST
+	- the default evaluation package is now
+		"Shell::Perl::sandbox"
 
-0.0008  Mar 13, 2007
-        - cmarcelo: some doc typos fixed
-        - a SEE ALSO section
-        - first CPAN release
+0.0008  Tue Mar 13 12:00:00 2007
+	- cmarcelo: some doc typos fixed
+	- a SEE ALSO section
+	- first CPAN release
 
-0.0007  Mar 7, 2007
-        - added some POD to Shell.pm and pirl source files
+0.0007  Wed Mar 07 12:00:00 2007
+	- added some POD to Shell.pm and pirl source files
 
-0.0006  Feb 23, 2007
-        - sources imported to Google code (no history :(, yet)
-        - patches by cmarcelo:
-          * implement list and void contexts for evaluation
-          * implement context override in a per-input basis
-        - we have tests now, even though t/98pod-coverage.t
-          does not pass yet
+0.0006  Fri Feb 23 12:00:00 2007
+	- sources imported to Google code (no history :(, yet)
+	- patches by cmarcelo:
+		* implement list and void contexts for evaluation
+		* implement context override in a per-input basis
+	- we have tests now, even though t/98pod-coverage.t
+		does not pass yet
 
-0.0005  Jan 27, 2007
-        - relax the restrictions during eval - no strict qw(vars subs)
+0.0005  Sat Jan 27 12:00:00 2007
+	- relax the restrictions during eval - no strict qw(vars subs)
 
-0.0004  Jan 25, 2007
-        - the same changes as before, now working
+0.0004  Thu Jan 25 12:00:00 2007
+	- the same changes as before, now working
 
-0.0003  Jan 25, 2007
-        - prompt changes with the script name
-        - psh renamed to pirl
-        - borked
+0.0003  Thu Jan 25 12:00:00 2007
+	- prompt changes with the script name
+	- psh renamed to pirl
+	- borked
 
-0.0002 ?
+0.0002  Wed Jan 24 12:00:00 2007
+	- Date fabricated.
 
-0.0001 ?
-
+0.0001  Tue Jan 23 12:00:00 2007
+	- Date fabricated.

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,52 +1,56 @@
+use strict;
+use warnings;
 
 use 5.008;
 use ExtUtils::MakeMaker;
 
 my $EUMM_VERSION = eval $ExtUtils::MakeMaker::VERSION;
 
-WriteMakefile(
-    NAME => 'Shell::Perl',
-    VERSION_FROM => 'lib/Shell/Perl.pm',
-    PREREQ_PM => {
-        Term::ReadLine  => 0,
-        File::Basename  => 0,
-        Class::Accessor => 0,
-        Getopt::Long    => 0,
-
-        File::Slurp => 0,
-        File::HomeDir => 0,
-        Path::Class => 0,
-
-        # test requires
-        'Test::More'      => 0,
-        'Test::Deep'      => 0,
-        'IPC::Cmd'        => 0,
-
+WriteMakefile
+(
+	NAME         => 'Shell::Perl',
+	VERSION_FROM => 'lib/Shell/Perl.pm',
+	EXE_FILES    => [ 'bin/pirl' ],
+	PREREQ_PM    =>
+	{
+		'Class::Accessor' => 0,
+		'File::Basename'  => 0,
+		'File::HomeDir'   => 0,
+		'File::Slurp'     => 0,
+		'Getopt::Long'    => 0,
+		'IPC::Cmd'	      => 0,
+		'Path::Class'     => 0,
+		'Test::Deep'      => 0,
+		'Test::More'      => 0,
+		'Term::ReadLine'  => 0,
     },
-    EXE_FILES => [ 'bin/pirl' ],
 
-    ($] >= 5.005 ? (
-        ABSTRACT_FROM  => 'lib/Shell/Perl.pm',
-        AUTHOR         => 'A. R. Ferreira <ferreira@cpan.org>',
-    ) : ()),
-    ($EUMM_VERSION >= 6.31 ? (
-        LICENSE => 'perl',
-    ) : ()),
-    ($EUMM_VERSION > 6.4501 ? (
-        META_MERGE => {
-            recommends => {
-                # optional tests
-                'Test::Pod'           => 0,
-                'Test::Pod::Coverage' => 0,
-                'Test::Script'        => 0,
-                'Test::Expect'        => 0,
-            },
-            resources => {
-                repository => 'http://github.com/aferreira/pirl',
-            },
-        },
-    ) : ()),
+	($] >= 5.005 ? (
+		ABSTRACT_FROM  => 'lib/Shell/Perl.pm',
+		AUTHOR	 => 'A. R. Ferreira <ferreira@cpan.org>',
+	) : ()),
 
+	($EUMM_VERSION >= 6.31 ? (
+		LICENSE => 'perl',
+	) : ()),
+
+	($EUMM_VERSION > 6.4501 ? (
+	META_MERGE =>
+	{
+		recommends =>
+		{
+			# optional tests
+			'Test::Pod'	   => 0,
+			'Test::Pod::Coverage' => 0,
+			'Test::Script'	=> 0,
+			'Test::Expect'	=> 0,
+		},
+		resources =>
+		{
+			repository => 'http://github.com/aferreira/pirl',
+	 	},
+	},
+	) : ()),
 );
 
 # recommended:

--- a/bin/pirl
+++ b/bin/pirl
@@ -6,7 +6,7 @@ use warnings;
 # /Id: pirl 1124 2007-01-25 19:36:07Z me / # don't erase that for now
 # $Id: /iperl/bin/pirl 2321 2008-03-09T16:47:36.686169Z a.r.ferreira@gmail.com  $
 
-our $VERSION = '1.23';
+our $VERSION = '0.0023';
 
 use Shell::Perl ();
 Shell::Perl->run_with_args;

--- a/lib/Shell/Perl.pm
+++ b/lib/Shell/Perl.pm
@@ -6,7 +6,7 @@ use warnings;
 # /Id: Perl.pm 1131 2007-01-27 17:43:35Z me / # don't erase that for now
 # $Id: /iperl/lib/Shell/Perl.pm 2317 2008-03-09T16:22:00.577930Z a.r.ferreira@gmail.com  $
 
-our $VERSION = '1.23';
+our $VERSION = '0.0023';
 
 use base qw(Class::Accessor); # soon use base qw(Shell::Base);
 Shell::Perl->mk_accessors(qw( out_type dumper context package term ornaments )); # XXX use_strict

--- a/lib/Shell/Perl/Dumper.pm
+++ b/lib/Shell/Perl/Dumper.pm
@@ -5,7 +5,7 @@ use warnings;
 
 # $Id$
 
-our $VERSION = '1.23';
+our $VERSION = '0.0023';
 
 use base qw(Class::Accessor); # to get a new() for free
 


### PR DESCRIPTION
Fix encoding issues, including making source file type utf8.

Also, my editor removes trailing spaces.
